### PR TITLE
Maintain API compat with stdlib Queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Maintain API compatibility with Queue from stdlib by returning `self` from `#clear`, `#enq`, and `#enq!`.
 
 ## [1.0.0] - 2019-04-18
 ### Added

--- a/lib/circular_queue.rb
+++ b/lib/circular_queue.rb
@@ -43,10 +43,12 @@ class CircularQueue
 
   # Adds an item to the queue
   # @param [Object] item item to add
+  # @return [CircularQueue] the queue itself
   def enq(item)
     @mutex.synchronize do
       enq_item(item)
       wakeup_next_waiter
+      self
     end
   end
   alias <<   enq
@@ -55,12 +57,14 @@ class CircularQueue
   # Adds an item to the queue, raising an error if the queue is full
   # @param [Object] item item to add
   # @raise [ThreadError] queue is full
+  # @return [CircularQueue] the queue itself
   def enq!(item)
     @mutex.synchronize do
       raise ThreadError.new("Queue is full") if full?
 
       enq_item(item)
       wakeup_next_waiter
+      self
     end
   end
   alias push! enq!
@@ -87,11 +91,13 @@ class CircularQueue
   alias pop   deq
 
   # Removes all items from the queue
+  # @return [CircularQueue] the queue itself
   def clear
     @mutex.synchronize do
       @size  = 0
       @front = 0
       @back  = 0
+      self
     end
   end
 

--- a/spec/circular_queue_spec.rb
+++ b/spec/circular_queue_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe CircularQueue do
       expect(queue.deq).to eq(1234)
     end
 
+    it "maintains the same API as Queue, returning itself" do
+      expect(queue.enq(1)).to eq(queue)
+      expect(queue.enq!(2)).to eq(queue)
+    end
+
     it "increases its size when a new item is added" do
       queue.enq(1234)
       expect(queue.size).to eq(1)
@@ -116,6 +121,10 @@ RSpec.describe CircularQueue do
       queue.clear
 
       expect(queue.size).to be_zero
+    end
+
+    it "maintains the same API as Queue, returning itself" do
+      expect(queue.clear).to eq(queue)
     end
   end
 


### PR DESCRIPTION
Meaning we should return `self` rather than `nil` or other less-than-meaningful values.